### PR TITLE
Fix terraform extension settings

### DIFF
--- a/src/terraform-basic/.devcontainer/devcontainer.json
+++ b/src/terraform-basic/.devcontainer/devcontainer.json
@@ -22,10 +22,8 @@
     "vscode": {
       "extensions": ["hashicorp.terraform"],
       "settings": {
-        "terraform.languageServer": {
-          "enabled": true,
-          "args": []
-        }
+        "terraform.languageServer.enable": true,
+        "terraform.languageServer.args": ["serve"]
       }
     }
   },


### PR DESCRIPTION
This updates the devcontainer config to use the correct settings for the HashiCorp Terraform VS Code extension. These settings were changed in [v2.24.0](https://github.com/hashicorp/vscode-terraform/blob/main/docs/settings-migration.md#settings-migration).

- The 'terraform.languageServer' setting was expanded into seperate settings instead of a single JSON object.
- The correct setting name is 'enable', not enabled.
- The args setting, if specified, needs to have at least 'serve' present.

This enables anyone using this devcontainer and an extension version greater than or equal to 2.24.0 to function correctly and not fail on load.
