### PR TITLE
Add serve argument so you don't get errors on build

### DIFF
--- a/src/terraform-basic/.devcontainer/devcontainer.json
+++ b/src/terraform-basic/.devcontainer/devcontainer.json
@@ -24,7 +24,9 @@
       "settings": {
         "terraform.languageServer": {
           "enabled": true,
-          "args": []
+          "args": [
+            "serve"
+          ]
         }
       }
     }


### PR DESCRIPTION
I received errors because I was missing the serve argument when I built this container.  It seems [others have run into this problem](https://discuss.hashicorp.com/t/manual-install-for-terraform-ls-in-vscode-remote-ssh-editor/13648/2) in ssh remote environments as well.